### PR TITLE
fix gl blending issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,8 @@ func onStart(glctx gl.Context) {
 	eng = glsprite.Engine(images)
 	game = NewGame()
 	scene = game.Scene(eng)
+	glctx.Enable(gl.BLEND)
+	glctx.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
 }
 
 func onStop() {


### PR DESCRIPTION
golang 1.5.2
OS-X 10.10 or iOS 9.1

expect:
![gopher-expect](https://cloud.githubusercontent.com/assets/616462/11645492/5052b080-9d98-11e5-90f9-43fe7bde562c.png)

instead:
![gopher-instead](https://cloud.githubusercontent.com/assets/616462/11645502/5515d2c8-9d98-11e5-986c-210f336b2333.png)

patch for enable BLEND-mode
